### PR TITLE
44 never print trace obstruction attenuation alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ This project uses [PyInstaller](https://pyinstaller.org/en/stable/) to convert t
 
 The build is done by executing the `build.py` file. The output executable (`.exe`) file will be located in `root/install/dist`. The `/install/build` folder are the temporary files used by PyInstaller to create the executable. I don't know what the `.spec` file is, but it doesn't seem to be required to run the executable.
 
+### N9010B Reference Docs
+
+Autosa was written to work with the N9010B signal analyzer. The [User's and Programmer's Reference](https://www.keysight.com/us/en/assets/9018-04666/user-manuals/9018-04666.pdf) was used to develop the SCPI commands.
+
 ### Terminology
 
 `band_ori` = "v", "h"

--- a/README.md
+++ b/README.md
@@ -89,3 +89,9 @@ Tenco used Autosa in the field for the first time on October 18th 2023 for railc
 Tenco used Autosa in January 2024 for the NYCT Crane Car Test in New York City.
 
 Tenco used Autosa in January 2024 for the Toshiba Electric Locomotive Commissioning Tests in Taiwan.
+
+# Notes
+
+### May 24 2024
+
+- added delay to run band, this should deal with the screenshotting of alerts with a small hit to time.

--- a/src/instrument/instrument.py
+++ b/src/instrument/instrument.py
@@ -246,6 +246,10 @@ def run_band(inst, settings, band_key, run_filename, save=True):
 
     # RECORD, ADJUST, AND SAVE
     record_and_adjust(inst, sweep_dur)
+    # this gives the instrument time to clear the screen of any alerts (they take about 3 seconds to clear)
+
+    time.sleep(5)
+
     if save:
         save_trace_and_screen(inst, run_filename, inst_out_folder, local_out_folder)
 


### PR DESCRIPTION
#44 
Went with the simplest fix of 5 second time delay before saves. This should allow alerts time to fade away. Not yet tested in the field